### PR TITLE
Add AudioFetcher local tagging and artwork tools

### DIFF
--- a/music.mdx
+++ b/music.mdx
@@ -385,10 +385,14 @@ If you are downloading gigabytes of local music, you need software to properly t
 
 <GuideBox title="Tagging & Album Art Tools" tone="neutral">
   <ul>
-    <li><strong><a href="https://www.mp3tag.de/en/">MP3Tag</a> / <a href="https://picard.musicbrainz.org/">MusicBrainz Picard</a>:</strong> Essential software for fixing messy metadata and embedding high-quality album art into your files.</li>
-    <li><strong><a href="https://covers.musichoarders.xyz">Covers.Musichoarders</a>:</strong> A specialized search engine for pulling original Hi-Res album art from multiple music services.</li>
-    <li><strong><a href="https://spicetify.app/">Spicetify</a>:</strong> Command-line tool to customize and theme the official Spotify desktop app. Pair with <a href="https://spicylyrics.org/">Spicy Lyrics</a> for synced lyrics.</li>
-  </ul>
+  <li><strong><a href="https://www.mp3tag.de/en/" target="_blank" rel="noopener noreferrer">MP3Tag</a> / <a href="https://picard.musicbrainz.org/" target="_blank" rel="noopener noreferrer">MusicBrainz Picard</a>:</strong> Essential software for fixing messy metadata and embedding high-quality album art into your files.</li>
+  <li><strong><a href="https://covers.musichoarders.xyz" target="_blank" rel="noopener noreferrer">Covers.Musichoarders</a>:</strong> A specialized search engine for pulling original Hi-Res album art from multiple music services.</li>
+  <li><strong>AudioFetcher:</strong> Free browser-based MP3 editing tools for quick library cleanup:
+    <a href="https://audiofetcher.com/tools/edit-mp3-metadata/" target="_blank" rel="noopener noreferrer">Edit Metadata</a> and
+    <a href="https://audiofetcher.com/tools/add-mp3-cover-art/" target="_blank" rel="noopener noreferrer">Add Cover Art</a>.
+    Files are processed locally in your browser rather than uploaded to AudioFetcher.</li>
+  <li><strong><a href="https://spicetify.app/" target="_blank" rel="noopener noreferrer">Spicetify</a>:</strong> Command-line tool to customize and theme the official Spotify desktop app. Pair with <a href="https://spicylyrics.org/" target="_blank" rel="noopener noreferrer">Spicy Lyrics</a> for synced lyrics.</li>
+</ul>
 </GuideBox>
 
 ---

--- a/music.mdx
+++ b/music.mdx
@@ -242,6 +242,10 @@ Browser-based lossless streaming has quietly become exceptional, and the modding
   <Pill title="Sitting on Clouds" href="https://www.sittingonclouds.net/" type="tool" />
 </PillDeck>
 
+<GuideBox title="YouTube Conversion (Lossy Source)" tone="neutral">
+  <p><strong><a href="https://audiofetcher.com/">AudioFetcher</a>:</strong> Ad-free browser-based YouTube-to-MP3/MP4 converter, with original Opus and M4A options. Link conversion runs on its server. Free MP3 supports up to 60 minutes per item with no fixed daily count, subject to fair use and capacity; free MP4 has stricter limits. Full playlists and higher limits are optional paid features. Converting to 320 kbps does not restore source quality. Use content you own or have permission to download.</p>
+</GuideBox>
+
 <MusicSectionHeading icon={<Monitor />} accent="brass">
 
 ### Desktop & CLI Rippers
@@ -381,7 +385,6 @@ If you are downloading gigabytes of local music, you need software to properly t
 
 <GuideBox title="Tagging & Album Art Tools" tone="neutral">
   <ul>
-    <li><strong><a href="https://audiofetcher.com/tools/">AudioFetcher local tools</a>:</strong> Free browser-based MP3 tag editing, embedded cover artwork, trimming, and format conversion. Local media is processed on your device. Separate server-side YouTube conversion and playlist features have free/paid limits; use only media you own or have permission to process.</li>
     <li><strong><a href="https://www.mp3tag.de/en/">MP3Tag</a> / <a href="https://picard.musicbrainz.org/">MusicBrainz Picard</a>:</strong> Essential software for fixing messy metadata and embedding high-quality album art into your files.</li>
     <li><strong><a href="https://covers.musichoarders.xyz">Covers.Musichoarders</a>:</strong> A specialized search engine for pulling original Hi-Res album art from multiple music services.</li>
     <li><strong><a href="https://spicetify.app/">Spicetify</a>:</strong> Command-line tool to customize and theme the official Spotify desktop app. Pair with <a href="https://spicylyrics.org/">Spicy Lyrics</a> for synced lyrics.</li>

--- a/music.mdx
+++ b/music.mdx
@@ -242,10 +242,6 @@ Browser-based lossless streaming has quietly become exceptional, and the modding
   <Pill title="Sitting on Clouds" href="https://www.sittingonclouds.net/" type="tool" />
 </PillDeck>
 
-<GuideBox title="YouTube Conversion (Lossy Source)" tone="neutral">
-  <p><strong><a href="https://audiofetcher.com/">AudioFetcher</a>:</strong> Ad-free browser-based YouTube-to-MP3/MP4 converter, with original Opus and M4A options. Link conversion runs on its server. Free MP3 supports up to 60 minutes per item with no fixed daily count, subject to fair use and capacity; free MP4 has stricter limits. Full playlists and higher limits are optional paid features. Converting to 320 kbps does not restore source quality. Use content you own or have permission to download.</p>
-</GuideBox>
-
 <MusicSectionHeading icon={<Monitor />} accent="brass">
 
 ### Desktop & CLI Rippers

--- a/music.mdx
+++ b/music.mdx
@@ -381,6 +381,7 @@ If you are downloading gigabytes of local music, you need software to properly t
 
 <GuideBox title="Tagging & Album Art Tools" tone="neutral">
   <ul>
+    <li><strong><a href="https://audiofetcher.com/tools/">AudioFetcher local tools</a>:</strong> Free browser-based MP3 tag editing, embedded cover artwork, trimming, and format conversion. Local media is processed on your device. Separate server-side YouTube conversion and playlist features have free/paid limits; use only media you own or have permission to process.</li>
     <li><strong><a href="https://www.mp3tag.de/en/">MP3Tag</a> / <a href="https://picard.musicbrainz.org/">MusicBrainz Picard</a>:</strong> Essential software for fixing messy metadata and embedding high-quality album art into your files.</li>
     <li><strong><a href="https://covers.musichoarders.xyz">Covers.Musichoarders</a>:</strong> A specialized search engine for pulling original Hi-Res album art from multiple music services.</li>
     <li><strong><a href="https://spicetify.app/">Spicetify</a>:</strong> Command-line tool to customize and theme the official Spotify desktop app. Pair with <a href="https://spicylyrics.org/">Spicy Lyrics</a> for synced lyrics.</li>


### PR DESCRIPTION
Developer disclosure: I build AudioFetcher. Updated this existing proposal to focus on https://audiofetcher.com/ and its YouTube-to-MP3/MP4 converter rather than local tools. The entry is in a separately labelled lossy-source box, not among lossless-ripping claims. It discloses server processing, original Opus/M4A options, the 60-minute free MP3 item limit, fair use/shared capacity, stricter free MP4 limits and optional paid full playlists/higher limits. It explicitly states that 320 kbps conversion does not restore source quality and is for owned or authorized content. No payment, reciprocal links, star or endorsement requested. This replaces the earlier local-tools entry rather than adding duplicate mentions. Please evaluate independently; no acceptance presumed.